### PR TITLE
fix install_all.sh script setuptools_scm pip dependency

### DIFF
--- a/scripts/install_all.sh
+++ b/scripts/install_all.sh
@@ -40,7 +40,8 @@ sudo apt-get update
 sudo apt-get install -y git pulseaudio python-pip python-mraa python-upm libmraa1 libupm1 mraa-tools libdbus-1-3 mpg123 mpv gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gir1.2-gstreamer-1.0 python-gi python-gst-1.0 python-pyaudio
 sudo apt-get install -y --reinstall librespeaker
 sudo apt-get install -y --reinstall respeakerd
-sudo pip install avs pixel_ring voice-engine pydbus pulsectl
+sudo pip install avs voice-engine pydbus pulsectl setuptools_scm
+sudo pip install pixel_ring
 
 H="/home/${DEFAULT_USER}"
 


### PR DESCRIPTION
Fixes #24 
Tested on `respeaker.io Debian Image 20180801` using `respeaker-debian-9-lxqt-flasher-20180801-4gb.img` boot image.